### PR TITLE
Fixes Deprecate preg_replace Call & Add GitHub Updating 

### DIFF
--- a/optimal.php
+++ b/optimal.php
@@ -5,7 +5,7 @@
  * Description: Renders valid OPML from any source in a tree-like view. Links to external OPML files as well as RSS, RDF, and Atom feeds are expanded in place.
  * Author: Dan MacTough
  * Author URI: http://www.yabfog.com/
- * Version: 0.4c (beta)
+ * Version: 0.5
  * GitHub Plugin URI: https://github.com/timnolte/optimal
  * License: GPL
  * 

--- a/optimal.php
+++ b/optimal.php
@@ -6,6 +6,7 @@ Description: Renders valid OPML from any source in a tree-like view. Links to ex
 Version: 0.4c (beta)
 Author: Dan MacTough
 Author URI: http://www.yabfog.com/
+GitHub Plugin URI: https://github.com/timnolte/optimal
 License: GPL
 
 Copyright (C) 2006 Dan MacTough

--- a/optimal.php
+++ b/optimal.php
@@ -1,33 +1,33 @@
 <?php
-/*
-Name: Optimal OPML Browser
-Homepage: http://www.yabfog.com/wp/optimal/
-Description: Renders valid OPML from any source in a tree-like view. Links to external OPML files as well as RSS, RDF, and Atom feeds are expanded in place.
-Version: 0.4c (beta)
-Author: Dan MacTough
-Author URI: http://www.yabfog.com/
-GitHub Plugin URI: https://github.com/timnolte/optimal
-License: GPL
-
-Copyright (C) 2006 Dan MacTough
-
-This program is free software; you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation; either version 2 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
-
-This is beta software, so please report any problems to
-danmactough AT yahoo DOT com
-*/
+/**
+ * Plugin Name: Optimal OPML Browser
+ * Plugin URI: http://www.yabfog.com/wp/optimal/
+ * Description: Renders valid OPML from any source in a tree-like view. Links to external OPML files as well as RSS, RDF, and Atom feeds are expanded in place.
+ * Author: Dan MacTough
+ * Author URI: http://www.yabfog.com/
+ * Version: 0.4c (beta)
+ * GitHub Plugin URI: https://github.com/timnolte/optimal
+ * License: GPL
+ * 
+ * Copyright (C) 2006 Dan MacTough
+ * 
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ * 
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ * 
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+ * 
+ * This is beta software, so please report any problems to
+ * danmactough AT yahoo DOT com
+ */
 
 //
 // Instantiate the class

--- a/optimalPlugin.php
+++ b/optimalPlugin.php
@@ -75,8 +75,8 @@ function OPMLContent ($content = '') {
 		} else {
 			$flags = 2;
 		}
-		$url = preg_replace('~&#x([0-9a-f]+);~ei', 'chr(hexdec("\\1"))', $url);
-		$url = preg_replace('~&#([0-9]+);~e', 'chr("\\1")', $url);
+		$url = preg_replace_callback('/&#x([0-9a-f]+)/i', function($matches) { return chr(hexdec($matches[0])); }, $url);
+		$url = preg_replace_callback('/&#([0-9]+)/', function($matches) { return chr($matches[0]); }, $url);
 		$url = html_entity_decode($url);
 		$find[] = "%". str_replace('?', '\?', $match[0]) ."%";
 		if ($flags & 1)


### PR DESCRIPTION
* Replaces the preg_replace with 'e' option call with a similar functioning call using preg_replace_callback.
* Adds GitHub Plugin URI to plugin comment header to support GitHub plugin updates.